### PR TITLE
Fix AutoGen package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'matplotlib',
         'pandas',
         'transformers>=4.39',
-        'pyautogen>=0.2.28',
+        'autogen-agentchat~=0.2.0',
         'powerlaw',
         'markdown2',
         'pdfkit',


### PR DESCRIPTION
We updated our package to `autogen-agentchat`. Also, the v0.4 (stable) version has been released, see migration guide: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/migration-guide.html