### PR TITLE
Update build with AG2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ This repository contains code for generating novel research ideas in the field o
 
 The notebook files ```SciAgents_ScienceDiscovery_GraphReasoning_non-automated.ipynb``` and ```SciAgents_ScienceDiscovery_GraphReasoning_automated.ipynb``` in the Notebooks directory correspond to the non-automated and automated multi-agent frameworks, respectively, as explained in the accompanying paper.
 
-The automated multi-agent model is implemented in [AG2](https://github.com/ag2ai/ag2?tab=readme-ov-file) (Formerly AutoGen), an open-source ecosystem for agent-based AI modeling. 
+The automated multi-agent model is implemented with [AG2](https://github.com/ag2ai/ag2?tab=readme-ov-file) (Formerly AutoGen), an open-source ecosystem for agent-based AI modeling. 
+This project is also collected in [Build with AG2](https://github.com/ag2ai/build-with-ag2), you can checkout more projects built with AG2.
 
 ### Audio file generation (podcast style, lecture, summary and others)
 


### PR DESCRIPTION
We are creating an official repo to collect use cases built with AG2. This PR updates a link to the [build-with-ag2](https://github.com/ag2ai/build-with-ag2) repo and we will also add link to this repo under `🔗 Links to More Projects Built with AG2` in build-with-ag2.