### PR TITLE
Fix UTF-8 encoding issues in markdown_to_pdf function

### DIFF
--- a/ScienceDiscovery/utils.py
+++ b/ScienceDiscovery/utils.py
@@ -94,10 +94,10 @@ def markdown_to_pdf(markdown_text, output_pdf_path):
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_md_path = f"{output_pdf_path}_{timestamp}.md"
     output_pdf_path = f"{output_pdf_path}_{timestamp}.pdf"
-
+    markdown_text_utf8 = markdown_text.encode('utf-8', 'ignore').decode('utf-8')
     # Save the Markdown text to a .md file
-    with open(output_md_path, 'w') as md_file:
-        md_file.write(markdown_text)   
+    with open(output_md_path, 'w', encoding='utf-8', errors='ignore') as md_file:
+        md_file.write(markdown_text_utf8)
 
     pdfkit.from_string(full_html, output_pdf_path)
 


### PR DESCRIPTION
**Title:** Fix UTF-8 encoding issues in markdown_to_pdf function

**Description:**
This change resolves file encoding problems within the markdown_to_pdf function in utils.py. It addresses encoding errors that could arise when processing markdown text containing non-ASCII characters.

**Specific changes:**
1. Added UTF-8 encoding handling for the input text:
   ```python
   markdown_text_utf8 = markdown_text.encode('utf-8', 'ignore').decode('utf-8')
   ```

2. Updated the file writing method to explicitly specify UTF-8 encoding and error handling:
   ```python
   with open(output_md_path, 'w', encoding='utf-8', errors='ignore')
   ```

**Related issues:**
- Resolves intermittent errors during Markdown document generation with Sciagent.

**This change ensures:**
- Proper handling of non-ASCII characters.
- Prevention of file writing errors due to encoding issues.
- Improved robustness and internationalization support of the function.

**Testing:**
- Tested markdown text containing Chinese non-ASCII characters.
- Confirmed that the generated PDF file correctly displays all characters.
